### PR TITLE
Build improvements for mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 
 # Build files
-*.o
+/obj
 libfunctors.so
+libfunctors.dylib
 
 # Output files
 out

--- a/makefile
+++ b/makefile
@@ -1,9 +1,16 @@
 
 .PHONY: functors run
 
+CFLAGS = -std=c++17 -fPIC $(EXTRA_CFLAGS)
+
 run:
 	souffle -Fsamples/multi_function -D- type_inference.dl
 
-functors:
-	g++ -c -fPIC src/functors/*.cpp
-	g++ -shared -o libfunctors.so functors.o set_functors.o list_functors.o ir_type_functors.o
+functors: libfunctors.so
+
+libfunctors.so: ${addprefix obj/, functors.o set_functors.o list_functors.o ir_type_functors.o}
+	g++ -shared -o $@ $+ 
+
+obj/%.o: src/functors/%.cpp
+	@mkdir -p ${dir $@}
+	g++ -c $(CFLAGS) -o $@ $<


### PR DESCRIPTION
Esp. these flags are needed for clang++: `-std=c++17 -fPIC`.
I think they should work for g++ as well, so perhaps you want to check.

I also added the `EXTRA_CFLAGS` var so that I can run `npm i` without having Soufflé installed globally.